### PR TITLE
Add workflows for AMD64 and ARM64 Snap build

### DIFF
--- a/.github/workflows/snap_amd64.yml
+++ b/.github/workflows/snap_amd64.yml
@@ -1,0 +1,60 @@
+name: Snap Build AMD64
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+
+    - uses: actions/checkout@v3
+      with:
+        fetch-tags: true
+
+    - uses: snapcore/action-build@v1
+      with:
+        snapcraft-channel: latest/edge
+      id: build-snap
+      env:
+        SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: 1
+
+    # Make sure the snap is installable
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+
+    # Save snap for subsequent job(s)
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wisevision-iot
+        path: ${{ steps.build-snap.outputs.snap }}
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+    # Retrieve the snap
+    - uses: actions/download-artifact@v4
+      with:
+        name: wisevision-iot
+        path: .
+
+    # Publish the snap on the store
+    - uses: snapcore/action-publish@v1
+      id: publish_snap
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+      with:
+        snap: ${{needs.build.outputs.snap-file}}
+
+    # Print the log file if the publish step fails
+    - name: Print Snapcraft Log
+      if: failure() && steps.publish_snap.outcome == 'failure'
+      run: |
+        ls -la /home/runner/.local/state/snapcraft/log/
+        cat /home/runner/.local/state/snapcraft/log/*.log

--- a/.github/workflows/snap_arm64.yml
+++ b/.github/workflows/snap_arm64.yml
@@ -1,0 +1,42 @@
+name: Snap Build ARM64
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-snap-and-push:
+    runs-on: wisevision-runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install script tool (pseudo-TTY)
+        run: sudo apt-get update && sudo apt-get install -y util-linux
+
+
+      - name: Run Snapcraft 
+        run: |
+          script -q -e -c "docker run --rm -it \
+            --privileged \
+            -v \"$PWD\":/build \
+            -w /build \
+            -e SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 \
+            diddledani/snapcraft:core22 \
+            /bin/bash -c 'find . -type d -exec chmod g-s {} + && snapcraft --destructive-mode'"
+
+      - name: Publish Snap to Snap Store
+        run: |
+          script -q -e --force /tmp/upload.log -c "docker run --rm -it \
+            --privileged \
+            -v \"$PWD\":/build \
+            -w /build \
+            -e SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 \
+            -e SNAPCRAFT_STORE_CREDENTIALS=\"$SNAPCRAFT_LOGIN\" \
+            diddledani/snapcraft:core22 \
+            snapcraft upload wisevision-iot_1.0_arm64.snap --release=stable"
+        env:
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 [![ROS2](https://img.shields.io/badge/ROS2-Humble%20|%20Jazzy-blue.svg)](https://docs.ros.org/)
 [![LoRaWAN](https://img.shields.io/badge/LoRaWAN-8000%2B%20devices-green.svg)](https://lora-alliance.org/)
 
+<p align="center">
+  <a href="https://snapcraft.io/wisevision-iot">
+    <img src="https://snapcraft.io/en/dark/install.svg" alt="Get it from the Snap Store">
+  </a>
+</p>
+
 > **Where ROS2 meets LoRaWAN** - Connect 8000+ LoRaWAN devices to the ROS2 ecosystem
 
 ![ros2_lorawan](docs/assets//readme_ros2_lorawan.png)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ parts:
       - grpc_install_dir
 
 
-  wisevision_proj_ros_packages:
+  wisevision-proj-ros-packages:
     plugin: colcon
     source: .
     after: [grpc]


### PR DESCRIPTION
## What does this PR do?
This pull request introduces automated workflows for building and publishing Snap packages for both AMD64 and ARM64 architectures, and includes a minor naming update in the Snapcraft configuration. The main focus is on enabling CI/CD for Snap builds and releases to the Snap Store.

**Continuous Integration and Deployment for Snap Packages:**

* Added `.github/workflows/snap_amd64.yml` to automate Snap build and publish for AMD64, including artifact upload and error logging.
* Added `.github/workflows/snap_arm64.yml` to automate Snap build and publish for ARM64 using a Docker-based Snapcraft environment.

**Configuration Update:**

* Renamed the `wisevision_proj_ros_packages` part to `wisevision-proj-ros-packages` in `snap/snapcraft.yaml` for consistency.
