### PR TITLE
CI files update

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -53,12 +53,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-      
-      - name: Configure Git for https access
-        run: |
-          git config --global url."https://${{ secrets.PAT_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Import repositories using vcs
         run: |
@@ -142,12 +136,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-      
-      - name: Configure Git for https access
-        run: |
-          git config --global url."https://${{ secrets.PAT_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Import repositories using vcs
         run: |


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow for building Docker images by removing the use of a personal access token (PAT) for repository checkout and related Git configuration steps. This reduces complexity and potential security risks in the workflow.

Workflow simplification:

* Removed the use of the `PAT_TOKEN` secret when checking out the repository with `actions/checkout@v3` in two places in the `.github/workflows/docker_images.yml` file. [[1]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L56-L61) [[2]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L145-L150)
* Removed the step that configured Git to use the PAT for HTTPS access to GitHub in both locations. [[1]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L56-L61) [[2]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L145-L150)