### PR TITLE
Add optional wisevision_msgs ref input for Docker image builds

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -13,6 +13,11 @@ on:
           - base
           - base-and-grpc
           - all
+      wisevision_msgs_ref:
+        description: 'wisevision_msgs ref (branch/tag/SHA) to build into the base image'
+        required: false
+        default: ''
+        type: string
   pull_request:
     branches:
       - main
@@ -141,6 +146,35 @@ jobs:
         run: |
           vcs import --recursive < ./docker-files/wisevision-base-image/image.repos
 
+      - name: Optionally override wisevision_msgs ref (workflow_dispatch only)
+        id: wisevision_msgs_ref
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REF="${{ github.event.inputs.wisevision_msgs_ref }}"
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || -z "$REF" ]]; then
+            echo "tag_suffix=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SAFE_REF="$(echo "$REF" | tr '/:@ ' '----' | tr -cd 'A-Za-z0-9_.-')"
+          if [[ -z "$SAFE_REF" ]]; then
+            echo "Ref '$REF' becomes empty after sanitization; please use a branch/tag/SHA with [A-Za-z0-9_.-/:@ ] characters." >&2
+            exit 1
+          fi
+
+          echo "tag_suffix=_${SAFE_REF}" >> "$GITHUB_OUTPUT"
+
+          cd src/wisevision_msgs
+          git fetch --all --tags --prune
+          if git show-ref --verify --quiet "refs/remotes/origin/$REF"; then
+            git checkout -B "$REF" "origin/$REF"
+          else
+            git checkout "$REF"
+          fi
+          git rev-parse HEAD
+
       - name: Install Docker CLI
         run: |
           apt-get update
@@ -165,7 +199,7 @@ jobs:
           docker buildx build --platform linux/amd64,linux/arm64 \
             --file docker-files/wisevision-base-image/Dockerfile \
             --build-arg BASE_IMAGE=${{ matrix.ros_distro }}-ros-base \
-            --tag ${{ secrets.DOCKER_HUB_USERNAME }}/ros_with_wisevision_msgs_and_wisevision_core:${{ matrix.ros_distro }} \
+            --tag ${{ secrets.DOCKER_HUB_USERNAME }}/ros_with_wisevision_msgs_and_wisevision_core:${{ matrix.ros_distro }}${{ steps.wisevision_msgs_ref.outputs.tag_suffix }} \
             --push \
             .
 


### PR DESCRIPTION
This pull request enhances the Docker image build workflow by adding support for optionally specifying a custom reference (branch, tag, or SHA) of the `wisevision_msgs` repository when triggering the workflow manually. This allows for more flexible and targeted builds, especially useful for testing changes in `wisevision_msgs` before merging.

**Workflow customization:**

* Added a new input parameter `wisevision_msgs_ref` to the workflow, allowing users to specify a branch, tag, or SHA for `wisevision_msgs` when manually dispatching the workflow (`workflow_dispatch`).

**Conditional checkout and build logic:**

* Introduced a new step that, when `wisevision_msgs_ref` is set, checks out the specified reference in the `src/wisevision_msgs` directory and generates a sanitized tag suffix for the Docker image. This ensures the built image reflects the chosen `wisevision_msgs` state.

**Docker image tagging:**

* Modified the Docker build command to append the sanitized `wisevision_msgs_ref` as a suffix to the Docker image tag, making it easy to identify images built from specific refs.