### PR TITLE
Fix Docker build arguments for ROS distribution in image workflows

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Docker build for ${{ matrix.ros_distro }}
         run: |
           docker build -t wisevision_base_and_grpc_image:${{ matrix.ros_distro }} \
-            --build-arg BASE_IMAGE=${{ matrix.ros_distro }} \
+            --build-arg ROS_DISTRO=${{ matrix.ros_distro }} \
             -f docker-files/wisevision-base-and-grpc-image/Dockerfile \
             .
 
@@ -245,7 +245,7 @@ jobs:
         run: |
           docker buildx build --platform linux/amd64,linux/arm64 \
             --file docker-files/wisevision-base-and-grpc-image/Dockerfile \
-            --build-arg BASE_IMAGE=${{ matrix.ros_distro }} \
+            --build-arg ROS_DISTRO=${{ matrix.ros_distro }} \
             --tag ${{ secrets.DOCKER_HUB_USERNAME }}/ros_with_wisevision_msgs_wisevision_core_and_grpc:${{ matrix.ros_distro }} \
             --push \
             .


### PR DESCRIPTION
## Summary

This PR updates the Docker build workflow to use a more appropriately named build argument when building images for different ROS distributions.

## Changes

- Updated the build argument from `BASE_IMAGE` to `ROS_DISTRO` in the `docker build` step for the base+gRPC image in `.github/workflows/docker_images.yml`.
- Updated the build argument from `BASE_IMAGE` to `ROS_DISTRO` in the `docker buildx build` (multi-arch) step for the base+gRPC image in `.github/workflows/docker_images.yml`.

## Why

The base+gRPC `Dockerfile` (`docker-files/wisevision-base-and-grpc-image/Dockerfile`) uses `ARG ROS_DISTRO`, so passing `BASE_IMAGE` was misleading and did not actually affect the selected ROS distro (potentially producing a `humble`-based image even when tagged as `jazzy`).

## Notes

No Dockerfile changes are included; this PR only updates the GitHub Actions workflow.
