### PR TITLE
Refactor conditionals for repository_dispatch in Docker image workflows

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -115,8 +115,8 @@ jobs:
             .
 
   build_and_push_base_image:
-    if: github.event_name == 'push' || 
-        (github.event_name == 'repository_dispatch' && github.event.action == 'trigger-build-and-push') || 
+    if: github.event_name == 'push' ||
+        github.event_name == 'repository_dispatch' ||
         (github.event_name == 'workflow_dispatch' && (github.event.inputs.build_target == 'base' || github.event.inputs.build_target == 'all'))
     runs-on: wisevision-runner
 
@@ -204,8 +204,8 @@ jobs:
             .
 
   build_and_push_base_and_grpc_image:
-    if: github.event_name == 'push' || 
-        (github.event_name == 'repository_dispatch' && github.event.action == 'trigger-build-and-push') || 
+    if: github.event_name == 'push' ||
+        github.event_name == 'repository_dispatch' ||
         (github.event_name == 'workflow_dispatch' && (github.event.inputs.build_target == 'base-and-grpc' || github.event.inputs.build_target == 'all'))
     needs: build_and_push_base_image
     runs-on: wisevision-runner

--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -16,6 +16,10 @@ jobs:
 
     continue-on-error: true
 
+    defaults:
+      run:
+        shell: bash
+
     container:
       image: ros:humble-ros-base
 
@@ -83,7 +87,6 @@ jobs:
 
     - name: Build test
       run: |
-        set -euo pipefail
         export GRPC_INSTALL_DIR=$HOME/grpc_install_dir
         export PATH=$GRPC_INSTALL_DIR/bin:$PATH
         export LD_LIBRARY_PATH=$GRPC_INSTALL_DIR/lib:$LD_LIBRARY_PATH
@@ -99,7 +102,6 @@ jobs:
 
     - name: Test result summary
       run: |
-        set -euo pipefail
         cd wisevision_ws
         . /opt/ros/humble/setup.sh
         colcon test --executor sequential --event-handlers console_direct+

--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -77,11 +77,6 @@ jobs:
         make -j$(nproc --ignore=2) 
         make install 
         cd -
-        if getent passwd "$(id -u)" >/dev/null 2>&1; then
-          rosdep fix-permissions
-        else
-          echo "Skipping rosdep fix-permissions: uid $(id -u) is not present in /etc/passwd"
-        fi
         rosdep update --include-eol-distros --rosdistro=humble
         cd $GITHUB_WORKSPACE/wisevision_ws/wisevision.proj
         rosdep install --from-paths src -i -y --rosdistro humble --skip-keys="Boost PahoMqtt"

--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -77,7 +77,11 @@ jobs:
         make -j$(nproc --ignore=2) 
         make install 
         cd -
-        rosdep fix-permissions
+        if getent passwd "$(id -u)" >/dev/null 2>&1; then
+          rosdep fix-permissions
+        else
+          echo "Skipping rosdep fix-permissions: uid $(id -u) is not present in /etc/passwd"
+        fi
         rosdep update --include-eol-distros --rosdistro=humble
         cd $GITHUB_WORKSPACE/wisevision_ws/wisevision.proj
         rosdep install --from-paths src -i -y --rosdistro humble --skip-keys="Boost PahoMqtt"

--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -20,6 +20,10 @@ jobs:
       image: ros:humble-ros-base
 
     steps:
+    - name: Install base tools required by container jobs
+      run: |
+        apt-get update
+        apt-get install -y git python3-pip python3-vcstool python3-rosdep python3-colcon-common-extensions
 
     - name: Create workspace directory
       run: |
@@ -41,18 +45,17 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y python3-rosdep libyaml-cpp-dev
+        apt-get update
+        apt-get install -y python3-rosdep libyaml-cpp-dev
         apt-get install -y wget build-essential gcc make cmake libssl-dev autoconf libtool pkg-config 
         apt-get install -y libpaho-mqtt-dev  libpaho-mqttpp-dev 
         apt-get install -y libboost-all-dev 
-        sudo apt-get install -y python3-pip libyaml-cpp-dev libjsoncpp-dev libcurl4-openssl-dev \
+        apt-get install -y python3-pip libyaml-cpp-dev libjsoncpp-dev libcurl4-openssl-dev \
                                 curl wget build-essential gcc make cmake libssl-dev autoconf \
-                                libtool pkg-config nodejs npm docker.io docker-compose
-        npm install -y react-router-dom
-        pip install flask
+                                libtool pkg-config
+        pip3 install flask
         if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
-          sudo rosdep init
+          rosdep init
         fi
         export GRPC_INSTALL_DIR=$HOME/grpc_install_dir 
         mkdir -p $GRPC_INSTALL_DIR 
@@ -74,29 +77,36 @@ jobs:
         make -j$(nproc --ignore=2) 
         make install 
         cd -
-        sudo rosdep fix-permissions
+        rosdep fix-permissions
         rosdep update --include-eol-distros --rosdistro=humble
         cd $GITHUB_WORKSPACE/wisevision_ws/wisevision.proj
-        rosdep install --from-path src -i -y --rosdistro humble  --skip-keys="Boost PahoMqtt"
+        rosdep install --from-paths src -i -y --rosdistro humble --skip-keys="Boost PahoMqtt"
 
     - name: Build test
       run: |
+        set -euo pipefail
         export GRPC_INSTALL_DIR=$HOME/grpc_install_dir
         export PATH=$GRPC_INSTALL_DIR/bin:$PATH
         export LD_LIBRARY_PATH=$GRPC_INSTALL_DIR/lib:$LD_LIBRARY_PATH
         cd wisevision_ws
         . /opt/ros/humble/setup.sh
-        colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+        # Keep logs streaming and reduce parallelism to avoid apparent hangs on heavy packages.
+        colcon build \
+          --symlink-install \
+          --event-handlers console_direct+ \
+          --executor sequential \
+          --parallel-workers 1 \
+          --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
 
     - name: Test result summary
       run: |
+        set -euo pipefail
         cd wisevision_ws
         . /opt/ros/humble/setup.sh
-        colcon test --executor sequential
+        colcon test --executor sequential --event-handlers console_direct+
         colcon test-result --verbose
 
     - name: Clean up workspace
       if: always()
       run: |
-        sudo rm -rf wisevision_ws
-
+        rm -rf wisevision_ws


### PR DESCRIPTION
This pull request makes a minor update to the workflow conditions in `.github/workflows/docker_images.yml`. The main change is simplifying the conditional logic that determines when the Docker image build jobs are triggered.

- Workflow Logic Simplification:
  * The conditions for triggering the `build_and_push_base_image` and `build_and_push_base_and_grpc_image` jobs have been updated to trigger on any `repository_dispatch` event, rather than only when `github.event.action` equals `trigger-build-and-push`. [[1]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L119-R119) [[2]](diffhunk://#diff-56fea898ae2a1a6afa408b46433395c02f1d8398d6078d6d0694944e9facf9e6L208-R208)