### PR TITLE
Update wisevision_msgs version to 2602 in image.repos

### DIFF
--- a/docker-files/wisevision-base-image/image.repos
+++ b/docker-files/wisevision-base-image/image.repos
@@ -2,7 +2,7 @@ repositories:
     src/wisevision_msgs:
         type: git
         url: https://github.com/wise-vision/wisevision_msgs.git
-        version: 2411
+        version: 2602
     src/wisevision_core:
         type: git
         url: https://github.com/wise-vision/wisevision_core.git


### PR DESCRIPTION
This pull request makes a minor update to the `docker-files/wisevision-base-image/image.repos` file by updating the version of the `wisevision_msgs` repository to 2602.